### PR TITLE
Update Delete-OldFolderVersions.ps1

### DIFF
--- a/Delete-OldFolderVersions.ps1
+++ b/Delete-OldFolderVersions.ps1
@@ -71,10 +71,10 @@ try {
 #Search for old versions
 write-host "Old OWA / ECP folders:"
 write-host ""
-[int]$ExchangeBuild = $ExchangeServerVersion.Replace(".","")
+$ExchangeBuild = [System.Version]::Parse($exchangeserverversion)
 $OldVersions = @()
 foreach ($Version in $AllVersions)  {
-    [int]$Folderversion = $Version.Name.Replace(".","")
+    $Folderversion = [System.Version]::Parse($Version.Name)
     if ( $Folderversion -lt $ExchangeBuild ) {
         write-host $Version.Fullname
         $OldVersions += $Version.Fullname


### PR DESCRIPTION
Das Skript nimmt als "aktuelle Version" das aktuell installierte CU, ohne Security Patch, also im Fall von CU21 "15.1.2308.8"
Beim Vergleich mit den Ordnerversionsnummern, sind die Securitypatche jedoch dabei, also bei CU19 "15.1.2176.12"

151217612 ist größer als 15123088, daher wird der Ordner nicht als der "ältere" erkannt.

Ich habe mal den Versionsvergleich angepasst, wodurch solche älteren Versionen mit höherer Revision auch erkannt werden.